### PR TITLE
fix: podmanとの互換性を保つためにnginxのイメージ指定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     build:
       context: nginx
       dockerfile: Dockerfile
+    image: docker.io/library/nginx:latest
     container_name: volatility-cmma-nginx
     depends_on:
       - api

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:alpine
+FROM nginx:latest
 
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
resolve #12 