### PR TITLE
fix: SQL文の文字列補間をホワイトリスト解決に一本化 (潜在SQLi)

### DIFF
--- a/api/crud.py
+++ b/api/crud.py
@@ -2,20 +2,44 @@ from sqlalchemy.orm import Session
 from sqlalchemy import text
 from typing import List, Dict, Any
 
+# テーブル名のホワイトリスト。timeframe -> テーブル名 のマップ。
+# ここに存在しないtimeframeはクエリを組み立てず例外(fail-closed)とする。
+TIMEFRAME_TABLE_MAP = {
+    "1m": "ohlcv_1m",
+    "5m": "ohlcv_5m",
+    "15m": "ohlcv_15m",
+    "30m": "ohlcv_30m",
+    "1h": "ohlcv_1h",
+    "4h": "ohlcv_4h",
+    "1d": "ohlcv_1d",
+    "1w": "ohlcv_1w",
+    "1M": "ohlcv_1M",
+}
+
+def _resolve_table_name(timeframe: str) -> str:
+    """ホワイトリストmapからテーブル名を解決する。未知の値はfail-closedで例外を投げる。"""
+    try:
+        return TIMEFRAME_TABLE_MAP[timeframe]
+    except KeyError:
+        raise ValueError(f"Unsupported timeframe: {timeframe}")
+
 def get_symbols_exceeding_threshold(db: Session, timeframe: str, price_threshold: float, offset: int, direction: str, sort: str, limit: int):
     """
     指定されたタイムフレームと閾値に基づいて、価格変動率が大きい銘柄のリストを取得します。
     offsetを使用して、何本前の足と比較するかを指定できます。
     """
-    table_name = f"ohlcv_{timeframe}"
+    table_name = _resolve_table_name(timeframe)
 
-    # ソート順をSQLのORDER BY句に変換
+    # ソート順をSQLのORDER BY句に変換 (fail-closed)
     sort_map = {
         "volatility_desc": "volatility_pct DESC",
         "volatility_asc": "volatility_pct ASC",
         "symbol_asc": "lc.symbol ASC",
     }
-    order_by_clause = sort_map.get(sort, "volatility_pct DESC")
+    try:
+        order_by_clause = sort_map[sort]
+    except KeyError:
+        raise ValueError(f"Unsupported sort: {sort}")
 
     # SQLクエリを構築
     # WITH句を使って、各シンボルごとに最新の足と、指定されたoffset前の足を取得する
@@ -102,7 +126,7 @@ def get_volume_for_period(db: Session, timeframe: str, period_str: str, sort: st
     """
     指定された期間とタイムフレームに基づいて、各銘柄の合計出来高を取得します。
     """
-    table_name = f"ohlcv_{timeframe}"
+    table_name = _resolve_table_name(timeframe)
 
     # Convert period string to seconds, then to milliseconds for timestamp comparison
     period_seconds = _parse_period_to_seconds(period_str)
@@ -110,7 +134,7 @@ def get_volume_for_period(db: Session, timeframe: str, period_str: str, sort: st
     start_ts = end_ts - timedelta(seconds=period_seconds)
     start_ts_ms = int(start_ts.timestamp() * 1000)
 
-    # Sort order mapping
+    # Sort order mapping (fail-closed)
     sort_map = {
         "volume_desc": "total_volume DESC",
         "volume_asc": "total_volume ASC",
@@ -118,7 +142,10 @@ def get_volume_for_period(db: Session, timeframe: str, period_str: str, sort: st
         "turnover_asc": "total_turnover ASC",
         "symbol_asc": "symbol ASC",
     }
-    order_by_clause = sort_map.get(sort, "total_volume DESC")
+    try:
+        order_by_clause = sort_map[sort]
+    except KeyError:
+        raise ValueError(f"Unsupported sort: {sort}")
 
     # Having clause based on min_volume_target
     having_clause = ""

--- a/api/main.py
+++ b/api/main.py
@@ -61,7 +61,8 @@ class SortBy(str, Enum):
     volatility_asc = "volatility_asc"
     symbol_asc = "symbol_asc"
 
-VALID_TIMEFRAMES = ["1m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M"]
+# 有効なタイムフレームは crud のホワイトリストmapから導出し、検証とテーブル名解決を常に同期させる
+VALID_TIMEFRAMES = list(crud.TIMEFRAME_TABLE_MAP.keys())
 
 # --- エンドポイント ---
 @app.get(
@@ -86,15 +87,18 @@ def read_volatility(
             headers={"X-Error-Code": "INVALID_TIMEFRAME"},
         )
     
-    results = crud.get_symbols_exceeding_threshold(
-        db=db, 
-        timeframe=timeframe, 
-        price_threshold=price_threshold,
-        offset=offset,
-        direction=direction.value,
-        sort=sort.value,
-        limit=limit
-    )
+    try:
+        results = crud.get_symbols_exceeding_threshold(
+            db=db, 
+            timeframe=timeframe, 
+            price_threshold=price_threshold,
+            offset=offset,
+            direction=direction.value,
+            sort=sort.value,
+            limit=limit
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e), headers={"X-Error-Code": "INVALID_INPUT"})
     
     # crudからの結果をレスポンスモデルに変換
     volatility_data = [
@@ -219,15 +223,18 @@ def read_volume(
             headers={"X-Error-Code": "INSUFFICIENT_HISTORY"}
         )
 
-    results = crud.get_volume_for_period(
-        db=db,
-        timeframe=timeframe,
-        period_str=period,
-        sort=sort.value,
-        limit=limit,
-        min_volume=min_volume or 0,
-        min_volume_target=min_volume_target.value,
-    )
+    try:
+        results = crud.get_volume_for_period(
+            db=db,
+            timeframe=timeframe,
+            period_str=period,
+            sort=sort.value,
+            limit=limit,
+            min_volume=min_volume or 0,
+            min_volume_target=min_volume_target.value,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e), headers={"X-Error-Code": "INVALID_INPUT"})
 
     volume_data = [
         schemas.VolumeData(


### PR DESCRIPTION
## 概要

SQL文への文字列補間をホワイトリストmapによるキー解決に一本化し、未知の値は例外(fail-closed)で遮断するよう修正しました。

## 影響

`api/crud.py` では `f"ohlcv_{timeframe}"` によるテーブル名と ORDER BY 句が文字列補間されており、現在は `api/main.py` の検証で遮断されていますが、検証がバイパスされた場合にSQLインジェクション(データ窃取・破壊)へ直結する可能性があります。

## 修正内容

- `api/crud.py`
  - `TIMEFRAME_TABLE_MAP` (timeframe → テーブル名) を追加し、テーブル名は `_resolve_table_name()` 経由でのみ解決するように変更。未知のtimeframeは `ValueError` を投げて fail-closed 化
  - ORDER BY も `sort_map.get()` からキー直接参照に変更し、未知の値は例外
  - `get_volume_for_period()` でも同じ解決を適用
- `api/main.py`
  - `VALID_TIMEFRAMES` を `crud.TIMEFRAME_TABLE_MAP` から導出し、検証とテーブル名解決の同期を保証
  - crud 呼び出しで `ValueError` が発生した場合は 400 (INVALID_INPUT) を返却