### PR TITLE
fix: /volume で period=1M 指定時に500が返る問題を解消

### DIFF
--- a/api/crud.py
+++ b/api/crud.py
@@ -85,17 +85,21 @@ def get_symbols_exceeding_threshold(db: Session, timeframe: str, price_threshold
 from datetime import datetime, timedelta
 
 def _parse_period_to_seconds(period_str: str) -> int:
-    """Parses a period string like '24h' or '7d' into seconds."""
-    unit = period_str[-1].lower()
+    """Parses a period string like '24h' or '7d' into seconds. 'M'は月(約30日)として扱う。"""
+    unit = period_str[-1]
     value = int(period_str[:-1])
 
+    if unit == 'M':  # 月 (約30日)
+        return value * 3600 * 24 * 30
+    unit = unit.lower()
     if unit == 'h':
         return value * 3600
     elif unit == 'd':
         return value * 3600 * 24
     elif unit == 'w':
         return value * 3600 * 24 * 7
-    # Add more units if needed (e.g., 'min' for minutes, 's' for seconds)
+    elif unit == 'm':  # 分
+        return value * 60
     raise ValueError(f"Unsupported period unit: {period_str}")
 
 def get_volume_for_period(db: Session, timeframe: str, period_str: str, sort: str, limit: int, min_volume: float = 0, min_volume_target: str = "turnover") -> List[Any]:

--- a/api/main.py
+++ b/api/main.py
@@ -139,8 +139,11 @@ VALID_PERIODS = ["1h", "6h", "12h", "24h", "1d", "7d", "1w", "1M"] # Add more as
 
 # Helper function to convert timeframe string to minutes
 def _parse_timeframe_to_minutes(timeframe_str: str) -> int:
-    unit = timeframe_str[-1].lower()
+    unit = timeframe_str[-1]
     value = int(timeframe_str[:-1])
+    if unit == 'M': # Assuming 'M' is for month, roughly 30 days
+        return value * 60 * 24 * 30
+    unit = unit.lower()
     if unit == 'm':
         return value
     elif unit == 'h':
@@ -149,23 +152,24 @@ def _parse_timeframe_to_minutes(timeframe_str: str) -> int:
         return value * 60 * 24
     elif unit == 'w':
         return value * 60 * 24 * 7
-    elif unit == 'M': # Assuming 'M' is for month, roughly 30 days
-        return value * 60 * 24 * 30
     raise ValueError(f"Unsupported timeframe unit: {timeframe_str}")
 
 # Helper function to convert period string to minutes (reusing from crud, but needs to be accessible here for validation)
 # This is a bit of duplication, but necessary for validation before CRUD call.
 def _parse_period_to_minutes(period_str: str) -> int:
-    unit = period_str[-1].lower()
+    unit = period_str[-1]
     value = int(period_str[:-1])
 
+    if unit == 'M': # 月 (約30日)
+        return value * 60 * 24 * 30
+    unit = unit.lower()
     if unit == 'h':
         return value * 60
     elif unit == 'd':
         return value * 60 * 24
     elif unit == 'w':
         return value * 60 * 24 * 7
-    elif unit == 'm' and len(period_str) > 1 and period_str[:-1].isdigit(): # Check if it's 'min' not 'month' for period
+    elif unit == 'm': # 分
         return value
     raise ValueError(f"Unsupported period unit: {period_str}")
 


### PR DESCRIPTION
## 概要

`GET /volume?timeframe=1h&period=1M` が必ず500を返す問題を修正しました。

## 影響

`VALID_PERIODS` には `1M` が含まれる一方、`api/crud.py` の `_parse_period_to_seconds()` が `'M'`(月) を未対応のまま `ValueError` を投げ、`api/main.py` の try/except がパース部分のみを対象としていたため、未捕捉の例外が500となっていました。

## 修正内容

- `api/crud.py` `_parse_period_to_seconds()`
  - `'M'`(月 = 約30日) と `'m'`(分) の単位ハンドリングを追加し、`1M` を月として正しく秒へ変換
- `api/main.py`
  - `_parse_timeframe_to_minutes()` / `_parse_period_to_minutes()` を crud と同一の仕様に統一。従来 `unit.lower()` の後で `'M'` を判定していたため dead code となっていたが、大文字 `'M'` を先に判定するように修正し、`1M` を一貫して30日として扱う
  - その結果、`required_candles` の計算も `1M` に対して正しくなり、履歴超過時は既存の `INSUFFICIENT_HISTORY` (400) で適切に返却されます