### PR TITLE
fix: 認証・レート制限なしAPIに対するDoS対策 (nginx limit_req)

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,11 +1,16 @@
 events {}
 
 http {
+    # レート制限ゾーン: クライアントIPあたり10rps、超過分は429を返す
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
+    limit_req_status 429;
+
     server {
         listen 80;
         server_name localhost;
 
         location / {
+            limit_req zone=api_limit burst=20 nodelay;
             proxy_pass http://api:8000;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 概要

認証なしで公開されているAPIエンドポイント (`/volatility`, `/volume`) への全表スキャン型クエリによるDoS攻撃を緩和するため、nginx にレート制限を追加しました。

## 影響

`api/crud.py:22-70` のウィンドウ関数、`api/crud.py:132-146` のGROUP BYフルスキャンは認証・レート制限なしで叩けるため、大量リクエストでDB・CPUリソースを枯渇させられる可能性があります。

## 修正内容

- `nginx/nginx.conf`
  - `limit_req_zone` を追加し、クライアントIPあたり 10r/s、バースト20、超過時は 429 を返す `limit_req` を全ロケーションに適用
  - `limit_req_status 429` を明示してレート超過時のレスポンスコードを確定